### PR TITLE
Issue #3 Expand the sample wiki with one more real-world gotcha

### DIFF
--- a/examples/sample-repo/.almanac/pages/payment-idempotency-keys.md
+++ b/examples/sample-repo/.almanac/pages/payment-idempotency-keys.md
@@ -1,0 +1,13 @@
+---
+title: Payment Idempotency Keys
+summary: "Always pass an idempotency key when calling the payment provider to safely retry authorizations."
+topics: [gotchas, payments]
+files:
+  - src/payments.ts
+---
+
+# Payment Idempotency Keys
+
+When retrying an authorization request with the payment provider, it is critical to use an idempotency key. This ensures that the payment provider will not charge the customer twice if the first request succeeded but we timed out while waiting for the response.
+
+Agents editing [[src/payments.ts]] should ensure that any calls to the provider include an idempotency key generated at the beginning of the checkout session.

--- a/examples/sample-repo/src/payments.ts
+++ b/examples/sample-repo/src/payments.ts
@@ -1,7 +1,7 @@
-export async function authorizePayment(amountCents: number): Promise<string> {
+export async function authorizePayment(amountCents: number, idempotencyKey?: string): Promise<string> {
   if (amountCents <= 0) {
     throw new Error("amountCents must be positive");
   }
 
-  return "receipt_sample";
+  return "receipt_sample_" + (idempotencyKey || "none");
 }


### PR DESCRIPTION
Fixes #3 

Hey! I added a new gotcha page for **Payment Idempotency Keys** to the sample repo so it feels a bit more like a real-world wiki. 

To make the example actually tie together, I also tweaked the dummy `authorizePayment` function in `src/payments.ts` to accept an `idempotencyKey` parameter. That way, the new docs actually match the sample code they're pointing to.

**What's included:**
- Created `payment-idempotency-keys.md` with the required frontmatter and a link to `[[src/payments.ts]]`.
- Updated `src/payments.ts` to take the new parameter.
- Tested it locally to make sure `almanac search` picks it up properly from inside `examples/sample-repo`.

Here's the search working locally:
<img width="741" height="60" alt="Screenshot 2026-06-28 at 4 03 50 PM" src="https://github.com/user-attachments/assets/5a293a66-3285-4f64-9995-667db053d952" />

Let me know if you need any changes!
