### PR TITLE
fix: automation platform guard -  setup and config set no longer crash on Linux

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,6 +145,11 @@ Setup installs agent instructions for your chosen tools and three local macOS
 These schedules run locally in the background. Use
 `codealmanac automation status` to see what is installed.
 
+On platforms other than macOS, `setup` still installs agent instructions and
+config but reports scheduled automation as unsupported instead of installing
+schedules; `codealmanac config set automation.*`/`config apply` fail with a
+clear error and change nothing.
+
 If you don't have Codex or prefer Claude, use `--runner claude`.
 
 `--target` only chooses which global agent instruction files to install; it does

--- a/src/codealmanac/cli/render/setup/result.py
+++ b/src/codealmanac/cli/render/setup/result.py
@@ -137,6 +137,13 @@ def product_update_step(result: SetupResult) -> SetupStep:
 
 
 def automation_step(result: SetupResult, task: AutomationTask, label: str) -> SetupStep:
+    if result.config_update.automation_error is not None:
+        return SetupStep(
+            label,
+            "unsupported",
+            result.config_update.automation_error,
+            warning=True,
+        )
     applied = {item.task: item for item in result.config_update.automation}
     item = applied.get(task)
     if item is None:
@@ -147,6 +154,13 @@ def automation_step(result: SetupResult, task: AutomationTask, label: str) -> Se
 
 
 def wiki_maintenance_step(result: SetupResult) -> SetupStep:
+    if result.config_update.automation_error is not None:
+        return SetupStep(
+            "Wiki maintenance",
+            "manual",
+            result.config_update.automation_error,
+            warning=True,
+        )
     if len(result.config_update.automation) == 0:
         return SetupStep("Wiki maintenance", "manual", "no schedules installed")
     installed = {item.task for item in result.config_update.automation if item.enabled}

--- a/src/codealmanac/integrations/automation/scheduler/launchd.py
+++ b/src/codealmanac/integrations/automation/scheduler/launchd.py
@@ -1,6 +1,7 @@
 import os
 import plistlib
 import subprocess
+import sys
 from dataclasses import dataclass
 from datetime import timedelta
 from pathlib import Path
@@ -24,6 +25,11 @@ class LaunchdInspection:
 
 
 class LaunchdSchedulerAdapter:
+    def unavailable_reason(self) -> str | None:
+        if sys.platform != "darwin":
+            return "scheduled automation is macOS-only for now (needs launchd)"
+        return None
+
     def install(self, job: ScheduledJob) -> ScheduledJobStatus:
         job.plist_path.parent.mkdir(parents=True, exist_ok=True)
         job.stdout_path.parent.mkdir(parents=True, exist_ok=True)

--- a/src/codealmanac/services/automation/ports.py
+++ b/src/codealmanac/services/automation/ports.py
@@ -12,3 +12,6 @@ class SchedulerAdapter(Protocol):
 
     def status(self, job: ScheduledJob) -> ScheduledJobStatus:
         """Read persisted scheduler state for one job."""
+
+    def unavailable_reason(self) -> str | None:
+        """Return why this scheduler cannot run here, or None when available."""

--- a/src/codealmanac/services/automation/service.py
+++ b/src/codealmanac/services/automation/service.py
@@ -1,5 +1,6 @@
 from pathlib import Path
 
+from codealmanac.core.errors import ExecutionFailed
 from codealmanac.services.automation.jobs import (
     AutomationJobFactory,
     default_job_for_task,
@@ -36,6 +37,9 @@ class AutomationService:
         request: ReconcileAutomationTaskRequest,
     ) -> AutomationTaskApplyResult:
         job = job_from_reconcile_request(self.jobs, request)
+        reason = self.scheduler.unavailable_reason()
+        if reason is not None:
+            raise ExecutionFailed(f"cannot apply scheduled automation: {reason}")
         if request.enabled:
             self.scheduler.install(job)
             changed = True
@@ -54,6 +58,8 @@ class AutomationService:
         request: RemoveAllAutomationRequest,
     ) -> AutomationRemoveResult:
         tasks = tuple(AutomationTask)
+        if self.scheduler.unavailable_reason() is not None:
+            return AutomationRemoveResult(tasks=tasks, removed=())
         removed: list[Path] = []
         for task in tasks:
             job = default_job_for_task(

--- a/src/codealmanac/services/config/models.py
+++ b/src/codealmanac/services/config/models.py
@@ -173,6 +173,7 @@ class ConfigUpdateResult(CodeAlmanacModel):
     path: str
     entries: tuple["ConfigEntry", ...]
     automation: tuple[AutomationTaskApplyResult, ...]
+    automation_error: str | None = None
 
 
 class ConfigEntry(CodeAlmanacModel):

--- a/src/codealmanac/services/config/service.py
+++ b/src/codealmanac/services/config/service.py
@@ -1,7 +1,7 @@
 from datetime import timedelta
 from pathlib import Path
 
-from codealmanac.core.errors import ValidationFailed
+from codealmanac.core.errors import ExecutionFailed, ValidationFailed
 from codealmanac.core.paths import normalize_path
 from codealmanac.services.automation.defaults import duration_text
 from codealmanac.services.automation.models import (
@@ -77,11 +77,21 @@ class ConfigService:
         path = normalize_path(self.user_config_path)
         self.store.set_values(path, user_config_updates(request))
         config = self.load_user()
-        applied = self.reconcile_all(config.automation, request)
+        # update() is setup's bulk onboarding call. A scheduler failure here
+        # (e.g. no launchd on this platform) should not abort instruction and
+        # harness config that already succeeded; set()/apply() are explicit,
+        # single-purpose commands and keep propagating scheduler failures.
+        automation_error = None
+        try:
+            applied = self.reconcile_all(config.automation, request)
+        except ExecutionFailed as error:
+            applied = ()
+            automation_error = str(error)
         return ConfigUpdateResult(
             path=path.as_posix(),
             entries=config_entries(config),
             automation=applied,
+            automation_error=automation_error,
         )
 
     def apply(self, request: ApplyConfigRequest) -> ConfigApplyResult:

--- a/tests/test_automation_service.py
+++ b/tests/test_automation_service.py
@@ -33,6 +33,9 @@ class FakeSchedulerAdapter:
         self.uninstalled: list[ScheduledJob] = []
         self.loaded: set[Path] = set()
 
+    def unavailable_reason(self) -> str | None:
+        return None
+
     def install(self, job: ScheduledJob) -> ScheduledJobStatus:
         self.installed.append(job)
         self.loaded.add(job.plist_path)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -204,6 +204,9 @@ class CliSchedulerAdapter:
         self.installed: list[ScheduledJob] = []
         self.uninstalled: list[ScheduledJob] = []
 
+    def unavailable_reason(self) -> str | None:
+        return None
+
     def install(self, job: ScheduledJob) -> ScheduledJobStatus:
         self.installed.append(job)
         return ScheduledJobStatus(
@@ -227,6 +230,22 @@ class CliSchedulerAdapter:
             installed=False,
             loaded=False,
         )
+
+
+class CliUnavailableSchedulerAdapter:
+    def unavailable_reason(self) -> str | None:
+        return "scheduled automation is macOS-only for now (needs launchd)"
+
+    def install(self, job: ScheduledJob) -> ScheduledJobStatus:
+        raise AssertionError("scheduler.install should not be called when unavailable")
+
+    def uninstall(self, job: ScheduledJob) -> bool:
+        raise AssertionError(
+            "scheduler.uninstall should not be called when unavailable"
+        )
+
+    def status(self, job: ScheduledJob) -> ScheduledJobStatus:
+        raise AssertionError("scheduler.status is not exercised in this test")
 
 
 class CliUpdateMetadataProvider:
@@ -397,6 +416,73 @@ def test_cli_setup_and_uninstall_codex_instructions(
         AutomationTask.GARDEN,
         AutomationTask.UPDATE,
     )
+
+
+def test_cli_setup_yes_skips_automation_cleanly_off_macos(
+    isolated_home: Path,
+    monkeypatch,
+    capsys,
+):
+    scheduler = CliUnavailableSchedulerAdapter()
+    app = create_app(
+        AppConfig(database_path=isolated_home / ".codealmanac/codealmanac.db"),
+        scheduler=scheduler,
+        harness_adapters=(CliNoopHarnessAdapter(),),
+    )
+    monkeypatch.setattr("codealmanac.cli.main.create_app", lambda: app)
+
+    exit_code = main(["setup", "--yes", "--target", "codex"])
+
+    captured = capsys.readouterr()
+    agents_path = isolated_home / ".codex/AGENTS.md"
+    assert exit_code == 0
+    assert captured.err == ""
+    assert "unsupported" in captured.out
+    assert "macOS-only" in captured.out
+    assert CODEALMANAC_START in agents_path.read_text(encoding="utf-8")
+    assert not (isolated_home / "Library/LaunchAgents").exists()
+
+
+def test_cli_config_set_automation_fails_cleanly_off_macos(
+    isolated_home: Path,
+    monkeypatch,
+    capsys,
+):
+    app = create_app(
+        AppConfig(database_path=isolated_home / ".codealmanac/codealmanac.db"),
+        scheduler=CliUnavailableSchedulerAdapter(),
+        harness_adapters=(CliNoopHarnessAdapter(),),
+    )
+    monkeypatch.setattr("codealmanac.cli.main.create_app", lambda: app)
+
+    exit_code = main(["config", "set", "automation.sync.every", "8h"])
+
+    captured = capsys.readouterr()
+    assert exit_code == 1
+    assert captured.out == ""
+    assert "codealmanac: cannot apply scheduled automation" in captured.err
+    assert "macOS-only" in captured.err
+    assert not (isolated_home / "Library/LaunchAgents").exists()
+
+
+def test_cli_uninstall_succeeds_even_when_scheduler_unavailable(
+    isolated_home: Path,
+    monkeypatch,
+    capsys,
+):
+    app = create_app(
+        AppConfig(database_path=isolated_home / ".codealmanac/codealmanac.db"),
+        scheduler=CliUnavailableSchedulerAdapter(),
+        harness_adapters=(CliNoopHarnessAdapter(),),
+        package_uninstaller=CliPackageUninstaller(),
+    )
+    monkeypatch.setattr("codealmanac.cli.main.create_app", lambda: app)
+
+    exit_code = main(["uninstall", "--yes"])
+
+    captured = capsys.readouterr()
+    assert exit_code == 0
+    assert "CodeAlmanac uninstall" in captured.out
 
 
 def test_cli_uninstall_without_yes_is_non_destructive_in_noninteractive_shell(

--- a/tests/test_config_service.py
+++ b/tests/test_config_service.py
@@ -6,10 +6,15 @@ import pytest
 from codealmanac.app import create_app
 from codealmanac.core.errors import ExecutionFailed, ValidationFailed
 from codealmanac.services.automation.models import ScheduledJob, ScheduledJobStatus
-from codealmanac.services.config.models import ConfigKey
+from codealmanac.services.config.models import (
+    AutomationConfig,
+    ConfigKey,
+    HarnessConfig,
+)
 from codealmanac.services.config.requests import (
     ApplyConfigRequest,
     SetConfigValueRequest,
+    UpdateUserConfigRequest,
 )
 from codealmanac.services.harnesses.models import HarnessKind
 from codealmanac.settings import AppConfig
@@ -19,6 +24,9 @@ class FakeScheduler:
     def __init__(self):
         self.installed: list[ScheduledJob] = []
         self.uninstalled: list[ScheduledJob] = []
+
+    def unavailable_reason(self) -> str | None:
+        return None
 
     def install(self, job: ScheduledJob) -> ScheduledJobStatus:
         self.installed.append(job)
@@ -30,6 +38,11 @@ class FakeScheduler:
 
     def status(self, job: ScheduledJob) -> ScheduledJobStatus:
         return scheduler_status(job, installed=False)
+
+
+class UnavailableScheduler(FakeScheduler):
+    def unavailable_reason(self) -> str | None:
+        return "scheduled automation is macOS-only for now (needs launchd)"
 
 
 class FailOnceScheduler(FakeScheduler):
@@ -233,6 +246,56 @@ def test_scheduler_failure_keeps_desired_toml_for_retry(
         "garden",
         "update",
     ]
+
+
+def test_config_set_fails_cleanly_when_scheduler_unavailable(
+    isolated_home: Path,
+) -> None:
+    scheduler = UnavailableScheduler()
+    app = config_app(isolated_home, scheduler)
+
+    with pytest.raises(ExecutionFailed, match="macOS-only"):
+        app.config.set(set_request(ConfigKey.AUTOMATION_SYNC_EVERY, "8h"))
+
+    assert app.config.load_user().automation.sync.every == timedelta(hours=8)
+    assert scheduler.installed == []
+    assert scheduler.uninstalled == []
+
+
+def test_config_apply_fails_cleanly_when_scheduler_unavailable(
+    isolated_home: Path,
+) -> None:
+    scheduler = UnavailableScheduler()
+    app = config_app(isolated_home, scheduler)
+
+    with pytest.raises(ExecutionFailed, match="macOS-only"):
+        app.config.apply(ApplyConfigRequest(home=isolated_home))
+
+    assert scheduler.installed == []
+    assert scheduler.uninstalled == []
+
+
+def test_config_update_skips_automation_cleanly_when_scheduler_unavailable(
+    isolated_home: Path,
+) -> None:
+    scheduler = UnavailableScheduler()
+    app = config_app(isolated_home, scheduler)
+
+    result = app.config.update(
+        UpdateUserConfigRequest(
+            auto_commit=False,
+            harness=HarnessConfig(),
+            automation=AutomationConfig(),
+            home=isolated_home,
+        )
+    )
+
+    assert result.automation == ()
+    assert result.automation_error is not None
+    assert "macOS-only" in result.automation_error
+    assert scheduler.installed == []
+    assert scheduler.uninstalled == []
+    assert app.config.load_user().auto_commit is False
 
 
 def test_config_apply_rejects_invalid_toml_without_scheduler_calls(

--- a/tests/test_setup_service.py
+++ b/tests/test_setup_service.py
@@ -24,6 +24,7 @@ from codealmanac.services.automation.requests import (
     ReconcileAutomationTaskRequest,
     RemoveAllAutomationRequest,
 )
+from codealmanac.services.automation.service import AutomationService
 from codealmanac.services.config.service import ConfigService
 from codealmanac.services.config.store import ConfigStore
 from codealmanac.services.harnesses.models import HarnessKind, HarnessReadiness
@@ -208,6 +209,29 @@ def test_setup_can_skip_sync_automation(home: Path):
         AutomationTask.GARDEN,
         AutomationTask.UPDATE,
     )
+
+
+def test_setup_skips_automation_cleanly_when_scheduler_unavailable(home: Path):
+    automation = AutomationService(UnavailableSchedulerAdapter())
+    config = ConfigService(
+        ConfigStore(),
+        home / ".codealmanac/config.toml",
+        automation,
+    )
+    service = SetupService(
+        FileInstructionInstaller(home),
+        automation,
+        FilesystemGlobalStateRemover(home / ".codealmanac"),
+        FakePackageUninstaller(skipped_package_result()),
+        config=config,
+    )
+
+    result = service.run(RunSetupRequest())
+
+    assert result.config_update.automation == ()
+    assert result.config_update.automation_error is not None
+    assert "macOS-only" in result.config_update.automation_error
+    assert result.changes[0].changed is True
 
 
 def test_uninstall_removes_automation_by_default(home: Path):
@@ -406,6 +430,24 @@ class FakeRunnerProbe:
             available=self.available,
             message=self.message,
         )
+
+
+class UnavailableSchedulerAdapter:
+    def unavailable_reason(self) -> str | None:
+        return "scheduled automation is macOS-only for now (needs launchd)"
+
+    def install(self, job):
+        raise AssertionError(
+            "scheduler.install should not be called when unavailable"
+        )
+
+    def uninstall(self, job):
+        raise AssertionError(
+            "scheduler.uninstall should not be called when unavailable"
+        )
+
+    def status(self, job):
+        raise AssertionError("scheduler.status is not exercised in this test")
 
 
 class FakeSetupAutomationManager:


### PR DESCRIPTION


## Summary

- `codealmanac config set automation.*`, `config apply`, and `setup` (which reconciles automation internally) unconditionally wire `LaunchdSchedulerAdapter`, which shells out to `launchctl`. On any non-macOS platform this crashed with a raw `launchctl bootstrap failed: No such file or directory` error, after already writing config, and left an orphaned `.plist` file in `~/Library/LaunchAgents/` that nothing would ever read. Even *disabling* automation crashed, since `uninstall()`'s new launchctl-not-found path doesn't match the "service not found" markers that would otherwise let it no-op.
- Added `unavailable_reason()` to the `SchedulerAdapter` port (mirroring the existing `HarnessReadiness` readiness-query pattern). `AutomationService.reconcile_task()`/`remove_all()` check it before touching the scheduler at all, so no plist is ever written and no `launchctl` call is attempted on an unsupported platform.


## Related issues #31
## Why

`AutomationService`'s constructor in `src/codealmanac/app.py` has no platform check, and the recent config-first automation redesign (`docs/plans/2026-07-10-user-toml-automation-preferences.md`) funnels every automation-enabling path — `config set`, `config apply`, and `setup`'s internal reconciliation — through one method, `AutomationService.reconcile_task()`. All three inherited the same unguarded crash.

The fix is asymmetric by design, matching how this codebase's own tests already treat these two call sites differently:

- `config set` / `config apply`: explicit, single-purpose user commands. They keep propagating scheduler failures as a clea`ExecutionFailed` (existing tests like `test_schtoml_for_retry` already assert this is thecontract for *any* scheduler error) — now that failure is immediate and writes nothing, instead of a raw traceback after a half-written plist.
- `setup`'s internal `ConfigService.update()` (confirmed via grep to be `SetupService`'s **only** caller — no CLI command calls
it): a bulk onboarding operation. A structural pdn't abort instruction/harness config thatalready succeeded, so it catches the same error and reports it via a new `automation_error` field instead of crashing setup.
`setup` still exits 0 with everything else insta

### Rejected alternative

Considered putting the platform guard directly ir.install()`/`uninstall()`. Rejected after itbroke 4 existing adapter-level unit tests (`test_launchd_adapter_writes_structured_plist` and others) that mock
`subprocess.run` directly and run on Linux CI (`/launchctl mechanics independent of host OS —those tests have nothing to do with whether the *real* host is macOS. Moved the platform fact to a separate, non-raising
`unavailable_reason()` query instead, consulted utomationService`), keeping the adapter's ownmocked-subprocess tests platform-agnostic.

## Tests

- `tests/test_config_service.py`: `config.set()`/`config.apply()` raise `ExecutionFailed` cleanly with no scheduler calls when
unavailable (`UnavailableScheduler`); `config.upreturning `automation_error` while stillpersisting other config values.
- `tests/test_setup_service.py`: end-to-end testService`/`ConfigService` stack (only the bottom`SchedulerAdapter` faked) confirming `SetupService.run()` doesn't raise and reports the reason.
- `tests/test_cli.py`: `codealmanac setup --yes`nsupported"/"macOS-only" step and no`Library/LaunchAgents` directory; `codealmanac config set automation.sync.every 8h` exits 1 with a clean message and writes
nothing; `codealmanac uninstall --yes` still sucnavailable.

## Verification

```bash
uv sync --locked
uv run ruff check .
uv run pytest
uv run codealmanac --help
uv build --out-dir dist
uvx twine check dist/*
git diff --check
```

All pass (471 tests). Also manually verified agaerAdapter` on a Linux machine: `configset`/`config apply` fail cleanly with no orphaned plist, `automation status` still works read-only.

## Docs and wiki

- [x] README/docs updated if user-facing behavior changed.
- [ ] `.almanac/` wiki updated if an implementatiant, or gotcha changed.
- [ ] Not applicable.

Wiki prose is written through `ingest`/`garden` lifecycle operations per this repo's convention, not hand-edited in a feature
PR; the existing wiki pages describing the macOSurate.

## Notes for reviewers

- `AutomationService.status()` needed no guard —tus()`/`inspect()` already degrade gracefully when `launchctl` is absent (catches the `OSError`, returns not-loaded), so `automation status` continues to work as a safe read-only command everywhere.
- Existing scheduler test doubles (`FakeSchedulerAdapter`, `FakeScheduler`, `CliSchedulerAdapter`) were updated to implement the extended protocol (`unavailable_reason()` rell prior test behavior.