### PR TITLE
fix(packaging): declare macOS support

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,7 @@ classifiers = [
   "Development Status :: 3 - Alpha",
   "Environment :: Console",
   "Intended Audience :: Developers",
-  "Operating System :: OS Independent",
+  "Operating System :: MacOS",
   "Programming Language :: Python :: 3",
   "Programming Language :: Python :: 3.12",
   "Topic :: Documentation",

--- a/tests/test_public_contract.py
+++ b/tests/test_public_contract.py
@@ -164,7 +164,8 @@ def test_python_package_metadata_declares_readme_and_license():
         "License :: OSI Approved :: Apache Software License"
         not in project["classifiers"]
     )
-    assert "Operating System :: OS Independent" in project["classifiers"]
+    assert "Operating System :: MacOS" in project["classifiers"]
+    assert "Operating System :: OS Independent" not in project["classifiers"]
     assert "Topic :: Software Development :: Documentation" in project["classifiers"]
 
 


### PR DESCRIPTION
## Summary

Correct the PyPI operating-system classifier so the package advertises its actual macOS-only runtime support instead of claiming to be OS independent. The public packaging contract test now guards against this regression.

Refs #24 and #31

## Why

The terminal import path is already guarded, but CodeAlmanac still relies on launchd for scheduling. Accurate package metadata prevents Windows and Linux users from being told the current release is platform independent.

## Validation

- uv run pytest — 564 passed
- uv run ruff check .
- uv build