### PR TITLE
fix(launcher): resolve Homebrew Cellar node paths to stable opt paths

### DIFF
--- a/archive/code/src/platform/install/launcher-runtime.ts
+++ b/archive/code/src/platform/install/launcher-runtime.ts
@@ -20,8 +20,14 @@ export async function writeInstallRuntime(args: {
   nodeVersion: string;
   nodeAbi?: string | null;
 }): Promise<void> {
+  let resolvedNodePath = args.nodePath;
+  const brewCellarRegex = /\/Cellar\/node\/[^/]+/i;
+  if (brewCellarRegex.test(resolvedNodePath)) {
+    resolvedNodePath = resolvedNodePath.replace(brewCellarRegex, "/opt/node");
+  }
+
   const runtime: InstallRuntime = {
-    nodePath: args.nodePath,
+    nodePath: resolvedNodePath,
     nodeVersion: args.nodeVersion,
     nodeAbi: args.nodeAbi ?? null,
   };

--- a/archive/code/test/launcher-runtime.test.ts
+++ b/archive/code/test/launcher-runtime.test.ts
@@ -42,6 +42,27 @@ describe("install launcher runtime", () => {
     });
   });
 
+  it("resolves Homebrew Cellar paths to stable opt paths", async () => {
+    await withTempHome(async (home) => {
+      const packageRoot = join(home, "pkg");
+      await mkdir(packageRoot, { recursive: true });
+
+      await writeInstallRuntime({
+        packageRoot,
+        nodePath: "/opt/homebrew/Cellar/node/26.0.0/bin/node",
+        nodeVersion: "v26.0.0",
+        nodeAbi: "147",
+      });
+
+      await expect(readInstallRuntime(packageRoot)).resolves.toEqual({
+        nodePath: "/opt/homebrew/opt/node/bin/node",
+        nodeVersion: "v26.0.0",
+        nodeAbi: "147",
+      });
+    });
+  });
+
+
   it("formats the repair message when the pinned node path is gone", () => {
     expect(
       formatMissingPinnedNodeMessage({


### PR DESCRIPTION
Resolves #61. Intercepts Homebrew versioned Cellar node paths and replaces them with stable opt symlink paths to prevent brew upgrade/cleanup from breaking the launcher pin.

